### PR TITLE
Use official eslint-plugin-import - version 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.2.2](https://github.com/contactlab/eslint-config-contactlab/releases/tag/4.2.2)
+
+**Dependencies:**
+
+- Use official eslint-plugin-import (#90)
+
 ## [4.2.1](https://github.com/contactlab/eslint-config-contactlab/releases/tag/4.2.1)
 
 **Dependencies:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -126,16 +126,6 @@
         }
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.17.0.tgz",
-      "integrity": "sha512-2bNf+mZ/3mj5/3CP56v+ldRK3vFy9jOvmCPs/Gr2DeSJh+asPZrhFniv4QmQsHWQFPJFWhFHgkGgJeRmK4m8iQ==",
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.17.0",
-        "eslint-scope": "^5.0.0"
-      }
-    },
     "@typescript-eslint/parser": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.18.0.tgz",
@@ -171,20 +161,6 @@
             "tsutils": "^3.17.1"
           }
         }
-      }
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.17.0.tgz",
-      "integrity": "sha512-g0eVRULGnEEUakxRfJO0s0Hr1LLQqsI6OrkiCLpdHtdJJek+wyd8mb00vedqAoWldeDcOcP8plqw8/jx9Gr3Lw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^6.3.0",
-        "tsutils": "^3.17.1"
       }
     },
     "acorn": {
@@ -648,8 +624,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "github:contactlab/eslint-plugin-import#aac1f22be2abf5b09f24a50edcc1ad4c27ff18ce",
-      "from": "github:contactlab/eslint-plugin-import",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
+      "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
       "requires": {
         "array-includes": "^3.0.3",
         "array.prototype.flat": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Contactlab ESLint configuration",
   "main": "index.js",
   "author": "Contactlab",
@@ -38,7 +38,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
-    "eslint-plugin-import": "github:contactlab/eslint-plugin-import",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsdoc": "^21.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR switches the `eslint-plugin-import` dependencies from Contactlab's fork to the official one

resolves #90 