### PR TITLE
Add Buildo eslint fp-ts plugin

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,11 @@ export = {
 
   plugins: ['node', 'import'],
 
-  extends: ['eslint:recommended', 'plugin:jsdoc/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:jsdoc/recommended',
+    'plugin:fp-ts/recommended'
+  ],
 
   rules: {
     // --- ES6
@@ -174,6 +178,13 @@ export = {
     'jsdoc/require-returns': 'off',
     'jsdoc/require-returns-check': 'off',
     'jsdoc/require-returns-description': 'off',
-    'jsdoc/require-returns-type': 'off'
+    'jsdoc/require-returns-type': 'off',
+
+    // --- fp-ts
+    'fp-ts/no-module-imports': 'off',
+    'fp-ts/no-redundant-flow': 'error',
+    'fp-ts/prefer-traverse': 'error',
+    'fp-ts/prefer-chain': 'error',
+    'fp-ts/prefer-bimap': 'error'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -295,6 +295,11 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "astring": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.6.0.tgz",
+      "integrity": "sha512-8Rhu9cQMu4CSie4IOTAgQl75kZ8dp+gmOipjCAkV1ZVSwuDXRKXDbi8YAlCOKzIh3mws/hNoXJu8EkZwfCakLQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -751,6 +756,24 @@
         "regexpp": "^3.0.0"
       }
     },
+    "eslint-plugin-fp-ts": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-fp-ts/-/eslint-plugin-fp-ts-0.1.11.tgz",
+      "integrity": "sha512-XKFQO2cj7FMQ12MWQyQQWQYO9R4+FgvrcdAbRorVG8M4hcb1XI9VtnQeDhON5WTHXMg0PISO8DgQdMSdnZNwKg==",
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.11.1",
+        "astring": "^1.4.3",
+        "estraverse": "^5.2.0",
+        "fp-ts": "^2.9.3"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
@@ -1048,6 +1071,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
       "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
       "dev": true
+    },
+    "fp-ts": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.3.tgz",
+      "integrity": "sha512-NjzcHYgigcbPQ6yJ52zwgsVDwKz3vwy9sjbxyzcvfXQm+j1BGeOPRuzLKEwsLyE4Xut6gG1FXJtsU9/gUB7tXg=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
+    "eslint-plugin-fp-ts": "^0.1.11",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^30.7.8",
     "eslint-plugin-node": "^11.1.0"


### PR DESCRIPTION
This PR:
- adds the [`eslint-plugin-fp-ts`](https://github.com/buildo/eslint-plugin-fp-ts) package

resolves #120 