### PR TITLE
Move fp-ts plugin in typescript config only

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ TypeScript configuration the `plugin:@typescript-eslint/recommended` rules.
 
 ## Older Nodejs versions
 
+### v12.x
+
+Since **v6.0.0** `eslint-config-contactlab` supports **Nodejs version >= 14.x**
+
+If you need support for **previous versions** please use **v5.0.0**
+
 ### v10.x
 
 Since **v5.0.0** `eslint-config-contactlab` supports **Nodejs version >= 12.x**

--- a/index.ts
+++ b/index.ts
@@ -12,11 +12,7 @@ export = {
 
   plugins: ['node', 'import'],
 
-  extends: [
-    'eslint:recommended',
-    'plugin:jsdoc/recommended',
-    'plugin:fp-ts/recommended'
-  ],
+  extends: ['eslint:recommended', 'plugin:jsdoc/recommended'],
 
   rules: {
     // --- ES6
@@ -178,13 +174,6 @@ export = {
     'jsdoc/require-returns': 'off',
     'jsdoc/require-returns-check': 'off',
     'jsdoc/require-returns-description': 'off',
-    'jsdoc/require-returns-type': 'off',
-
-    // --- fp-ts
-    'fp-ts/no-module-imports': 'off',
-    'fp-ts/no-redundant-flow': 'error',
-    'fp-ts/prefer-traverse': 'error',
-    'fp-ts/prefer-chain': 'error',
-    'fp-ts/prefer-bimap': 'error'
+    'jsdoc/require-returns-type': 'off'
   }
 };

--- a/typescript.ts
+++ b/typescript.ts
@@ -12,10 +12,12 @@ export = {
   extends: [
     './index.js',
     'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended'
+    'plugin:@typescript-eslint/recommended',
+    'plugin:fp-ts/recommended'
   ],
 
   rules: {
+    // --- Typescript
     '@typescript-eslint/array-type': [
       'error',
       {
@@ -103,6 +105,13 @@ export = {
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'off',
     '@typescript-eslint/semi': ['error', 'always'],
-    '@typescript-eslint/unified-signatures': 'error'
+    '@typescript-eslint/unified-signatures': 'error',
+
+    // --- fp-ts
+    'fp-ts/no-module-imports': 'off',
+    'fp-ts/no-redundant-flow': 'error',
+    'fp-ts/prefer-traverse': 'error',
+    'fp-ts/prefer-chain': 'error',
+    'fp-ts/prefer-bimap': 'error'
   }
 };


### PR DESCRIPTION
This PR fixes a bug in the default javascript configuration file (`index.ts` which generates the `contactlab` standard eslint config).

The configuration extended the `recommended` config and set some rules of the [`fp-ts` plugin](https://github.com/buildo/eslint-plugin-fp-ts), but the plugin needs Typescript and so it cannot be used in a standard ESLint, _javascript-only_, environment.

Both were moved to the Typescript config file (`typescript.ts`). 