### PR TITLE
Disable the no-shadow and enable @typescript-eslint/no-shadow

### DIFF
--- a/typescript.ts
+++ b/typescript.ts
@@ -17,7 +17,7 @@ export = {
   ],
 
   rules: {
-    "no-shadow": "off",
+    'no-shadow': 'off',
     // --- Typescript
     '@typescript-eslint/array-type': [
       'error',
@@ -96,7 +96,7 @@ export = {
       {ignoreParameters: true}
     ],
     '@typescript-eslint/no-parameter-properties': 'off',
-    "@typescript-eslint/no-shadow": ["error"],
+    '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       {

--- a/typescript.ts
+++ b/typescript.ts
@@ -17,7 +17,9 @@ export = {
   ],
 
   rules: {
+    // --- ES
     'no-shadow': 'off', // Disable basic rule in favor of `@typescript-eslint/no-shadow`
+
     // --- Typescript
     '@typescript-eslint/array-type': [
       'error',

--- a/typescript.ts
+++ b/typescript.ts
@@ -17,7 +17,7 @@ export = {
   ],
 
   rules: {
-    'no-shadow': 'off',
+    'no-shadow': 'off', // Disable basic rule in favor of `@typescript-eslint/no-shadow`
     // --- Typescript
     '@typescript-eslint/array-type': [
       'error',

--- a/typescript.ts
+++ b/typescript.ts
@@ -17,6 +17,7 @@ export = {
   ],
 
   rules: {
+    "no-shadow": "off",
     // --- Typescript
     '@typescript-eslint/array-type': [
       'error',
@@ -95,6 +96,7 @@ export = {
       {ignoreParameters: true}
     ],
     '@typescript-eslint/no-parameter-properties': 'off',
+    "@typescript-eslint/no-shadow": ["error"],
     '@typescript-eslint/no-unused-vars': [
       'error',
       {


### PR DESCRIPTION
This PR:

- disables the standard `ES` rule `no-shadow` in favor of `@typescript-eslint/no-shadow` in Typescript config

resolves #217