### PR TITLE
no-unused-vars - destructuredArrayIgnorePattern: starts with _

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [8.1.0](https://github.com/contactlab/eslint-config-contactlab/releases/tag/8.1.0)
+
+**Feature:**
+
+- Ignore unused elements of destructured arrays which start with `_` (#447)
+
+**Dependencies:**
+
+- [Security] Bump minimist from 1.2.5 to 1.2.6 (#441)
+
 ## [8.0.0](https://github.com/contactlab/eslint-config-contactlab/releases/tag/8.0.0)
 
 **Breaking:**

--- a/index.ts
+++ b/index.ts
@@ -90,7 +90,8 @@ export = {
     'no-unused-vars': [
       'error',
       {
-        argsIgnorePattern: '^_$'
+        argsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_'
       }
     ],
     'no-useless-call': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-contactlab",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "8.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "@typescript-eslint/typescript-estree": "^5.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.17.0",
+        "@typescript-eslint/parser": "^5.17.0",
+        "@typescript-eslint/typescript-estree": "^5.17.0",
         "eslint-plugin-fp-ts": "^0.3.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jsdoc": "^38.0.3",
@@ -196,32 +196,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-      "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
@@ -418,32 +392,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-      "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
@@ -3010,20 +2958,6 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.17.0.tgz",
           "integrity": "sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw=="
         },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-          "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-          "requires": {
-            "@typescript-eslint/types": "5.17.0",
-            "@typescript-eslint/visitor-keys": "5.17.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
         "@typescript-eslint/utils": {
           "version": "5.17.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.17.0.tgz",
@@ -3124,20 +3058,6 @@
           "version": "5.17.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.17.0.tgz",
           "integrity": "sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw=="
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-          "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-          "requires": {
-            "@typescript-eslint/types": "5.17.0",
-            "@typescript-eslint/visitor-keys": "5.17.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
         },
         "@typescript-eslint/utils": {
           "version": "5.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Contactlab ESLint configuration",
   "main": "index.js",
   "author": "Contactlab",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
-    "@typescript-eslint/typescript-estree": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.17.0",
+    "@typescript-eslint/parser": "^5.17.0",
+    "@typescript-eslint/typescript-estree": "^5.17.0",
     "eslint-plugin-fp-ts": "^0.3.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^38.0.3",

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@
 
 import * as path from 'path';
 
-export function test() {
-  return path.join('this', 'is', 'a', 'simple', 'test');
+export function test(_unused, is = 'is') {
+  const [_, a, simple, Test] = ['not', 'a', 'simple', 'test'];
+
+  return path.join('this', is, a, simple, Test);
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,6 +5,8 @@
 
 import * as path from 'path';
 
-export function test(): string {
-  return path.join('this', 'is', 'a', 'simple', 'test');
+export function test(_unused: unknown, is = 'is'): string {
+  const [_, a, simple, Test] = ['not', 'a', 'simple', 'test'];
+
+  return path.join('this', is, a, simple, Test);
 }

--- a/typescript.ts
+++ b/typescript.ts
@@ -102,7 +102,8 @@ export = {
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
-        argsIgnorePattern: '^_$'
+        argsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_'
       }
     ],
     '@typescript-eslint/no-use-before-define': 'off',


### PR DESCRIPTION
This PR adds the [`destructuredArrayIgnorePattern`](https://eslint.org/docs/rules/no-unused-vars#destructuredarrayignorepattern) option to the `no-unused-vars` rule in order to make legit unused elements of destructured arrays which start with `_`.

This change applies to both `js` and `ts` config thanks to version [5.17.0](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#5170-2022-03-28) of `@typescript-eslint`

resolves #447 