### PR TITLE
Drop Node v12 + add Node v18 to tests matrix

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -18,7 +18,7 @@ jobs:
     # --- Execute the job with 4 different versions of Node
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     # --- Job tasks
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-contactlab",
-      "version": "8.1.0",
+      "version": "9.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contactlab",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Contactlab ESLint configuration",
   "main": "index.js",
   "author": "Contactlab",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "contactlab"
   ],
   "engines": {
-    "node": ">= 12.20",
+    "node": ">= 14",
     "npm": ">= 6.13"
   },
   "files": [


### PR DESCRIPTION
This PR:
- drops Node v12 (removing it from tests matrix and bumping the version in the package.json `engine` field);
- adds Node v18 to `node-version` matrix in GitHub Actions pipeline;
- bumps package's version to 9.0.0

resolves #492 