### PR TITLE
Remove deprecated rules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,43 +10,27 @@ export = {
     sourceType: 'module'
   },
 
-  plugins: ['node', 'import'],
+  plugins: ['@stylistic/js', 'node', 'import'],
 
   extends: ['eslint:recommended', 'plugin:jsdoc/recommended'],
 
   rules: {
     // --- ES6
     'arrow-body-style': ['error', 'as-needed'],
-    'arrow-parens': ['error', 'as-needed'],
-    'arrow-spacing': [
-      'error',
-      {
-        before: true,
-        after: true
-      }
-    ],
-    'brace-style': 'error',
     camelcase: [
       'error',
       {
         properties: 'never'
       }
     ],
-    'comma-dangle': 'error',
     complexity: 'off',
     curly: 'error',
     'default-case': 'off',
     'dot-notation': 'error',
-    'eol-last': 'off',
     eqeqeq: 'error',
     'guard-for-in': 'error',
     'id-match': 'error',
-    indent: 'off',
-    'linebreak-style': ['error', 'unix'],
     'max-classes-per-file': 'off',
-    'max-len': 'off',
-    'new-parens': 'off',
-    'newline-per-chained-call': 'off',
     'no-bitwise': 'error',
     'no-caller': 'error',
     'no-case-declarations': 'off',
@@ -55,15 +39,12 @@ export = {
     'no-eval': 'error',
     'no-extend-native': 'error',
     'no-extra-bind': 'error',
-    'no-extra-semi': 'off',
     'no-fallthrough': 'off',
-    'no-floating-decimal': 'error',
     'no-implicit-coercion': 'error',
     'no-implicit-globals': 'error',
     'no-invalid-this': 'off',
     'no-irregular-whitespace': 'off',
     'no-lone-blocks': 'error',
-    'no-multiple-empty-lines': 'off',
     'no-native-reassign': 'error',
     'no-nested-ternary': 'error',
     'no-new-func': 'error',
@@ -77,7 +58,6 @@ export = {
     ],
     'no-script-url': 'error',
     'no-throw-literal': 'error',
-    'no-trailing-spaces': 'off',
     'no-undef-init': 'error',
     'no-undefined': 'off',
     'no-underscore-dangle': 'error',
@@ -112,24 +92,14 @@ export = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    quotes: [
-      'error',
-      'single',
-      {
-        avoidEscape: true,
-        allowTemplateLiterals: true
-      }
-    ],
-    'quote-props': 'off',
     radix: 'error',
-    semi: ['error', 'always'],
-    'space-before-function-paren': 'off',
-    'space-in-parens': ['error', 'never'],
-    'spaced-comment': 'error',
     'sort-keys': 'off',
     'vars-on-top': 'error',
-    'wrap-iife': ['error', 'inside'],
     'valid-typeof': 'off',
+
+    // --- Stylistic
+    '@stylistic/js/spaced-comment': 'error',
+    '@stylistic/js/wrap-iife': ['error', 'inside'],
 
     // --- Node
     'node/global-require': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "11.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@stylistic/eslint-plugin-js": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@typescript-eslint/typescript-estree": "^6.0.0",
@@ -167,6 +168,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.0.0.tgz",
+      "integrity": "sha512-xxvjyYnUEgjBTnXKYMk6JbU0LHkf269d6y4IgW69bK/VwHrqLfdgE6mYvft42U7KVpp6Tbf6Z64tLRYD/rYd/A==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "acorn": "^8.10.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esutils": "^2.0.3",
+        "graphemer": "^1.4.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -3861,6 +3876,20 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@stylistic/eslint-plugin-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.0.0.tgz",
+      "integrity": "sha512-xxvjyYnUEgjBTnXKYMk6JbU0LHkf269d6y4IgW69bK/VwHrqLfdgE6mYvft42U7KVpp6Tbf6Z64tLRYD/rYd/A==",
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "acorn": "^8.10.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esutils": "^2.0.3",
+        "graphemer": "^1.4.0"
       }
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
+    "@stylistic/eslint-plugin-js": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@typescript-eslint/typescript-estree": "^6.0.0",


### PR DESCRIPTION
This PR removes formatting rules [deprecated from ESLint version 8.53.0](https://eslint.org/blog/2023/10/deprecating-formatting-rules/)